### PR TITLE
Avoid Re-creating Functions

### DIFF
--- a/__tests__/useHistoryWithQuery.test.js
+++ b/__tests__/useHistoryWithQuery.test.js
@@ -25,6 +25,8 @@ describe("useHistoryWithQuery", () => {
       wrapper: makeWrapper(history)
     });
 
+    // Assert that original history is mutated (to preserve callbacks)
+    expect(result.current).toBe(history);
     expect(result.current.location.pathname).toBe("/path");
     expect(result.current.location.search).toBe(
       "?one=1&two=value&arr=A&arr=B&arr=C"

--- a/__tests__/useQueryParams.test.js
+++ b/__tests__/useQueryParams.test.js
@@ -61,4 +61,35 @@ describe("useHistoryWithQuery", () => {
     });
     expect(history.entries).toHaveLength(2);
   });
+
+  it("accepts functional query string update", () => {
+    const { result } = renderHook(
+      () => useQueryParams({ parseNumbers: true }),
+      { wrapper: makeWrapper(history) }
+    );
+
+    act(() => {
+      result.current[1].replaceQuery(query => ({ ...query, one: 2, a: "B" }));
+    });
+
+    expect(result.current[0]).toEqual({
+      one: 2,
+      two: "value",
+      arr: ["A", "B", "C"],
+      a: "B"
+    });
+    expect(history.entries).toHaveLength(1);
+
+    act(() => {
+      result.current[1].pushQuery(query => ({ ...query, a: "A" }));
+    });
+
+    expect(result.current[0]).toEqual({
+      one: 2,
+      two: "value",
+      arr: ["A", "B", "C"],
+      a: "A"
+    });
+    expect(history.entries).toHaveLength(2);
+  })
 });

--- a/src/useHistoryWithQuery.js
+++ b/src/useHistoryWithQuery.js
@@ -4,17 +4,17 @@ import queryString from "query-string";
 
 import withParsedQuery from "./withParsedQuery";
 
-const wrapWithQuery = (navigate, options) => (location, state) => {
-  if (typeof location === "object" && location.query) {
-    const search = queryString.stringify(location.query, options);
-    navigate({ ...location, search }, state);
-  } else {
-    navigate(location, state);
-  }
-};
+const wrapWithQuery = (navigate, options) => (location, state) =>
+  typeof location === "object" && location.query
+    ? navigate(
+        { ...location, search: queryString.stringify(location.query, options) },
+        state
+      )
+    : navigate(location, state);
 
 export default ({ queryOptions } = {}) => {
-  const { location, push, replace, ...history } = useHistory();
+  const history = useHistory();
+  const { location, push, replace } = history;
 
   const pushWithQuery = useCallback(wrapWithQuery(push, queryOptions), [
     push,
@@ -26,10 +26,9 @@ export default ({ queryOptions } = {}) => {
     queryOptions
   ]);
 
-  return {
-    ...history,
+  return Object.assign(history, {
     location: withParsedQuery(location, queryOptions),
     push: pushWithQuery,
     replace: replaceWithQuery
-  };
+  });
 };

--- a/src/useQueryParams.js
+++ b/src/useQueryParams.js
@@ -1,10 +1,24 @@
 import { useCallback } from "react";
 import useHistoryWithQuery from "./useHistoryWithQuery";
 
-export default queryOptions => {
-  const { location, push, replace } = useHistoryWithQuery({ queryOptions });
-  const pushQuery = useCallback(query => push({ query }), [push]);
-  const replaceQuery = useCallback(query => replace({ query }), [replace]);
+const updateURL = (history, type, update) =>
+  history[type]({
+    query:
+      typeof update === "function" ? update(history.location.query) : update
+  });
 
-  return [location.query, { pushQuery, replaceQuery }];
+export default queryOptions => {
+  const history = useHistoryWithQuery({ queryOptions });
+
+  const pushQuery = useCallback(
+    update => updateURL(history, "push", update),
+    [history]
+  );
+
+  const replaceQuery = useCallback(
+    update => updateURL(history, "replace", update),
+    [history]
+  );
+
+  return [history.location.query, { pushQuery, replaceQuery }];
 };


### PR DESCRIPTION
This PR does two things:

1. It preserves the history object from react-router, and mutates it (by adding properties and wrapping `replace` & `push`.
2. It accepts a "functional update" like state setters, to avoid having to depend on current state (and therefore re-creating the callback/function).