### PR TITLE
Fix bug with separate history context

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Test](https://github.com/aaronpanch/react-router-query-hooks/workflows/Test/badge.svg)
 
-A small package that augments the basic `react-router-dom` hooks (`useLocation` and `useHistory`) to be more query string aware by parsing using the `query-string` library.
+A small package that augments the basic [`react-router-dom`](https://reactrouter.com/web/guides/quick-start) hooks (`useLocation` and `useHistory`) to be more query string aware by parsing using the [`query-string`](https://github.com/sindresorhus/query-string) library.
 
 Primarily, it exports a simple `useQueryParams` hook for reading and manipulating the URL query string (useful for UIs where sort order, or page number is encoded in the URL). See the usage notes for more details.
 
@@ -87,6 +87,7 @@ This modified hook builds upon React Router's [`history`](https://reacttraining.
 
 - In `history.location`, it adds the `query` key to React Router's [`location` object](https://reacttraining.com/react-router/web/api/location) (as above)
 - Furthermore, it supports URL updates with the `query` key. So `history.replace` supports both paths (as before) and location objects with the `query` key.
+- **GOTCHA:** React router does NOT trigger an update to `history.location` when the location changes. While the _internal_ history object is updated, this is a mutation, and React will not update the component.  You must listen to the location separately using `useLocationWithQuery` or the combined `useQueryParams` to update the component upon a location change.
 
 ```jsx
 import { useHistory } from "react-router-dom";

--- a/__tests__/useHistoryWithQuery.test.js
+++ b/__tests__/useHistoryWithQuery.test.js
@@ -75,9 +75,6 @@ describe("useHistoryWithQuery", () => {
       result.current.replace({ query: { two: "stuff" } });
     });
 
-    expect(result.current.location.query).toEqual({
-      two: "stuff"
-    });
     expect(history.entries[0].search).toEqual("?two=stuff");
   });
 
@@ -101,9 +98,6 @@ describe("useHistoryWithQuery", () => {
       result.current.push({ query: { two: "stuff" } });
     });
 
-    expect(result.current.location.query).toEqual({
-      two: "stuff"
-    });
     expect(history.entries[1].search).toEqual("?two=stuff");
   });
 
@@ -127,9 +121,6 @@ describe("useHistoryWithQuery", () => {
       result.current.push("/path?two=stuff");
     });
 
-    expect(result.current.location.query).toEqual({
-      two: "stuff"
-    });
     expect(history.entries[1].search).toEqual("?two=stuff");
   });
 });

--- a/__tests__/useQueryParams.test.js
+++ b/__tests__/useQueryParams.test.js
@@ -10,7 +10,7 @@ const makeWrapper = history => ({ children }) => (
   <Router history={history}>{children}</Router>
 );
 
-describe("useHistoryWithQuery", () => {
+describe("useQueryParams", () => {
   let history;
 
   beforeEach(() => {
@@ -91,5 +91,5 @@ describe("useHistoryWithQuery", () => {
       a: "A"
     });
     expect(history.entries).toHaveLength(2);
-  })
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -4909,11 +4909,6 @@
       "dev": true,
       "optional": true
     },
-    "gud": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
-    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -6141,13 +6136,22 @@
       "dev": true
     },
     "mini-create-react-context": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz",
-      "integrity": "sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
+      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
       "requires": {
-        "@babel/runtime": "^7.4.0",
-        "gud": "^1.0.0",
-        "tiny-warning": "^1.0.2"
+        "@babel/runtime": "^7.12.1",
+        "tiny-warning": "^1.0.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "minimatch": {
@@ -6666,15 +6670,15 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-router": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.1.2.tgz",
-      "integrity": "sha512-yjEuMFy1ONK246B+rsa0cUam5OeAQ8pyclRDgpxuSCrAlJ1qN9uZ5IgyKC7gQg0w8OM50NXHEegPh/ks9YuR2A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "history": "^4.9.0",
         "hoist-non-react-statics": "^3.1.0",
         "loose-envify": "^1.3.1",
-        "mini-create-react-context": "^0.3.0",
+        "mini-create-react-context": "^0.4.0",
         "path-to-regexp": "^1.7.0",
         "prop-types": "^15.6.2",
         "react-is": "^16.6.0",
@@ -6683,15 +6687,15 @@
       }
     },
     "react-router-dom": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.1.2.tgz",
-      "integrity": "sha512-7BPHAaIwWpZS074UKaw1FjVdZBSVWEk8IuDXdB+OkLb8vd/WRQIpA4ag9WQk61aEfQs47wHyjWUoUGGZxpQXew==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
+      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "history": "^4.9.0",
         "loose-envify": "^1.3.1",
         "prop-types": "^15.6.2",
-        "react-router": "5.1.2",
+        "react-router": "5.2.0",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "query-string": "^6.11.1",
-    "react-router-dom": "^5.1.0"
+    "react-router-dom": "^5.2.0"
   },
   "peerDependencies": {
     "react": "^16.8.0",

--- a/src/useQueryParams.js
+++ b/src/useQueryParams.js
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import useLocationWithQuery from "./useLocationWithQuery";
 import useHistoryWithQuery from "./useHistoryWithQuery";
 
 const updateURL = (history, type, update) =>
@@ -8,17 +9,17 @@ const updateURL = (history, type, update) =>
   });
 
 export default queryOptions => {
+  const location = useLocationWithQuery({ queryOptions });
   const history = useHistoryWithQuery({ queryOptions });
 
-  const pushQuery = useCallback(
-    update => updateURL(history, "push", update),
-    [history]
-  );
+  const pushQuery = useCallback(update => updateURL(history, "push", update), [
+    history
+  ]);
 
   const replaceQuery = useCallback(
     update => updateURL(history, "replace", update),
     [history]
   );
 
-  return [history.location.query, { pushQuery, replaceQuery }];
+  return [location.query, { pushQuery, replaceQuery }];
 };


### PR DESCRIPTION
This PR fixes a bug with the separation of a history context in React Router DOM 5.2
- History object is reused when a location update happens, therefore we need to listen with `useLocation` to trigger a component update.
- Relax `useHistoryWithQuery` tests to support location field not updating _on render_.